### PR TITLE
[Private Note] Ensure no plaintext can be posted to the backend

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,9 @@
 name: Lint
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ main ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,9 @@
 name: Lint
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,5 +1,6 @@
 export default class Routes {
   static readonly PRIVATE_NOTES = "/private-note/";
+  static readonly PRIVATE_NOTE_CREATE = "/private-note/create";
   static readonly PRIVATE_NOTE = (id: string = ":id", hash = ":hash") =>
     `/private-note/${id}#${hash}`;
   static readonly JSON = "/json";

--- a/app/routes/private-note.tsx
+++ b/app/routes/private-note.tsx
@@ -1,6 +1,17 @@
-export default function Security() {
+import { Outlet } from "@remix-run/react";
+import type { MetaFunction } from "@remix-run/cloudflare";
+
+export const meta: MetaFunction = () => ({
+  title: "Private Note | Utiliti",
+});
+
+export default function PrivateNote() {
   return (
     <>
+      <h1>Private Note</h1>
+
+      <Outlet />
+
       <h2>Security & Privacy</h2>
       <p>
         We aim to make private notes as secure as possible by taking the

--- a/app/routes/private-note/$id.tsx
+++ b/app/routes/private-note/$id.tsx
@@ -5,8 +5,6 @@ import type { Location } from "@remix-run/react";
 import { Link, useLoaderData, useLocation } from "@remix-run/react";
 import React, { useEffect, useState } from "react";
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
-import Security from "~/routes/private-note/_security";
-import type { MetaFunction } from "@remix-run/cloudflare";
 import {
   ArrowSmallLeftIcon,
   ArrowSmallRightIcon,
@@ -21,10 +19,6 @@ type LoaderData = {
   readonly expiration: number;
   readonly needsConfirmation: boolean;
 };
-
-export const meta: MetaFunction = () => ({
-  title: "Private Note | Utiliti",
-});
 
 export const loader: LoaderFunction = async ({
   request,
@@ -66,7 +60,7 @@ export const loader: LoaderFunction = async ({
   return {
     ciphertext: note.value,
     needsConfirmation: false,
-    expiration: note?.metadata?.expiration || 0,
+    expiration: deleteAfterRead ? 0 : note?.metadata?.expiration || 0,
   };
 };
 
@@ -98,13 +92,7 @@ export default function PrivateNote() {
   // if this note is supposed to be deleted after it's shown, show a confirmation
   // this also makes it so that tools that inspect URLs do not inadvertently read the node.
   if (loaderData.needsConfirmation) {
-    return (
-      <>
-        <Title />
-        <Confirm location={location} />
-        <Security />
-      </>
-    );
+    return <Confirm location={location} />;
   }
 
   // if we ran into a decryption error, show an error page
@@ -116,40 +104,31 @@ export default function PrivateNote() {
 
   // finally, show the note
   return (
-    <>
-      <Title />
-
-      <div className="w-full mb-4 border rounded-lg bg-zinc-700 border-zinc-600">
-        <div className="flex items-center justify-end px-3 py-2 border-b border-gray-600 font-bold">
-          <div>
-            <Copy content={plainText} />
-          </div>
-        </div>
-        <div className="px-4 py-2 bg-zinc-800">
-          <ReadOnlyTextArea value={plainText} />
-        </div>
-        <div className="flex px-3 py-2 border-t border-gray-600 rounded-b-lg text-sm items-center">
-          <InformationCircleIcon className="h-5 w-5 mr-1" aria-hidden="true" />
-          {expiration === 0 ? (
-            <span>
-              This note is now deleted. Copy the content in the note before
-              closing this window.
-            </span>
-          ) : (
-            <span>
-              This note will be deleted on{" "}
-              {new Date(expiration * 1000).toLocaleString()}.
-            </span>
-          )}
+    <div className="w-full mb-4 border rounded-lg bg-zinc-700 border-zinc-600">
+      <div className="flex items-center justify-end px-3 py-2 border-b border-gray-600 font-bold">
+        <div>
+          <Copy content={plainText} />
         </div>
       </div>
-      <Security />
-    </>
+      <div className="px-4 py-2 bg-zinc-800">
+        <ReadOnlyTextArea value={plainText} />
+      </div>
+      <div className="flex px-3 py-2 border-t border-gray-600 rounded-b-lg text-sm items-center">
+        <InformationCircleIcon className="h-5 w-5 mr-1" aria-hidden="true" />
+        {expiration === 0 ? (
+          <span>
+            This note is now deleted. Copy the content in the note before
+            closing this window.
+          </span>
+        ) : (
+          <span>
+            This note will be deleted on{" "}
+            {new Date(expiration * 1000).toLocaleString()}.
+          </span>
+        )}
+      </div>
+    </div>
   );
-}
-
-function Title() {
-  return <h1>Private Notes</h1>;
 }
 
 function Confirm({ location }: { readonly location: Location }) {
@@ -175,8 +154,6 @@ function Confirm({ location }: { readonly location: Location }) {
 function Error({ message }: { readonly message: string }) {
   return (
     <>
-      <Title />
-
       <p className="lead">{message}</p>
 
       <div className="not-prose flex flex-col items-start gap-3">

--- a/app/routes/private-note/create.tsx
+++ b/app/routes/private-note/create.tsx
@@ -1,0 +1,46 @@
+import type { ActionFunction } from "@remix-run/router";
+import { createId } from "@paralleldrive/cuid2";
+import { noteExpiries } from "~/routes/private-note/index";
+
+export type CreateActionData = {
+  readonly id: string;
+};
+/**
+ * This file is only responsible for saving the ciphertext into Cloudflare KV and returning the id.
+ *
+ * It is placed in a file that returns no UI component, because we don't want this functionality to work
+ * without javascript enabled, otherwise it would potentially post plaintext to us, and we never want that data.
+ *
+ * @param request
+ * @param context
+ */
+export const action: ActionFunction = async ({
+  request,
+  context,
+}): Promise<CreateActionData> => {
+  const privateNotesNs = context.PRIVATE_NOTES as KVNamespace;
+
+  // grab submitted data
+  const formData = await request.formData();
+  const id = createId();
+  const expiry = formData.get("expiry") as string;
+  const ciphertext = formData.get("input") as string;
+  const expiryObject = noteExpiries.find((it) => it.id === expiry);
+
+  if (!expiryObject) {
+    throw new Response("Invalid Expiry", { status: 400 });
+  }
+
+  // store ciphertext in kv store
+  const expiration = Math.floor(Date.now() / 1000) + expiryObject.ttl;
+  await privateNotesNs.put(id, ciphertext, {
+    expiration,
+    metadata: {
+      deleteAfterRead: expiryObject.id === "0",
+      expiration,
+    },
+  });
+
+  // return only the id back to the frontend
+  return { id };
+};

--- a/app/routes/private-note/create.tsx
+++ b/app/routes/private-note/create.tsx
@@ -5,6 +5,7 @@ import { noteExpiries } from "~/routes/private-note/index";
 export type CreateActionData = {
   readonly id: string;
 };
+
 /**
  * This file is only responsible for saving the ciphertext into Cloudflare KV and returning the id.
  *

--- a/app/routes/private-note/index.tsx
+++ b/app/routes/private-note/index.tsx
@@ -96,6 +96,7 @@ export default function Index() {
           className="font-mono w-full px-0 text-sm border-0 bg-zinc-800 focus:ring-0 text-white placeholder-zinc-400"
           placeholder="Write your note here..."
           required={true}
+          maxLength={1048576 /* ~1 MB in characters */}
         ></textarea>
       </div>
 

--- a/app/routes/private-note/index.tsx
+++ b/app/routes/private-note/index.tsx
@@ -1,24 +1,12 @@
-import type { MetaFunction } from "@remix-run/cloudflare";
 import Button from "~/components/button";
-import type { FormEvent } from "react";
 import { useCallback, useRef, useState } from "react";
-import { Form, useActionData, useSubmit } from "@remix-run/react";
-import type { ActionFunction } from "@remix-run/router";
-import { createId, init } from "@paralleldrive/cuid2";
+import { useFetcher } from "@remix-run/react";
+import { init } from "@paralleldrive/cuid2";
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
-import Security from "~/routes/private-note/_security";
 import { encrypt } from "~/utils/aes";
 import Routes from "~/routes";
 import Copy from "~/components/copy";
-
-export const meta: MetaFunction = () => ({
-  title: "Private Note | Utiliti",
-});
-
-type ActionData = {
-  readonly error?: string;
-  readonly id: string;
-};
+import type { CreateActionData } from "~/routes/private-note/create";
 
 export type NoteMetadata = {
   readonly deleteAfterRead: boolean;
@@ -53,85 +41,44 @@ export const noteExpiries = [
   },
 ];
 
-export const action: ActionFunction = async ({ request, context }) => {
-  const privateNotesNs = context.PRIVATE_NOTES as KVNamespace;
-
-  // grab submitted data
-  const formData = await request.formData();
-  const id = createId();
-  const expiry = formData.get("expiry") as string;
-  const ciphertext = formData.get("input") as string;
-  const expiryObject = noteExpiries.find((it) => it.id === expiry);
-
-  if (!expiryObject) {
-    throw new Response("Invalid Expiry", { status: 400 });
-  }
-
-  // store ciphertext in kv store
-  const expiration = Math.floor(Date.now() / 1000) + expiryObject.ttl;
-  await privateNotesNs.put(id, ciphertext, {
-    expiration,
-    metadata: {
-      deleteAfterRead: expiryObject.id === "0",
-      expiration,
-    },
-  });
-
-  // return only the id back to the frontend
-  return { id };
-};
-
-const Title = () => <h1>Private Notes</h1>;
-
 export default function Index() {
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const formRef = useRef<HTMLFormElement>(null);
   const passwordRef = useRef<string | null>(null);
   const [expiry, setExpiry] = useState("0");
-  const submit = useSubmit();
-  const actionData = useActionData<ActionData>();
+  const fetcher = useFetcher<CreateActionData>();
 
   // on submit, encrypt the plaintext and then send it to the action
-  const onSubmit = useCallback(
-    async (e: FormEvent<HTMLFormElement>) => {
-      if (!inputRef.current) {
-        return;
-      }
+  const onSubmit = useCallback(async () => {
+    if (!inputRef.current) {
+      return;
+    }
 
-      // stop form submission
-      e.preventDefault();
+    // generate a password (shortening the length as collisions here are not important)
+    const cuid = init({ length: 10 });
+    passwordRef.current = cuid();
 
-      // generate a password (shortening the length as collisions here are not important)
-      const cuid = init({ length: 10 });
-      passwordRef.current = cuid();
+    // encrypt data
+    const ciphertext = await encrypt(
+      inputRef.current.value,
+      passwordRef.current
+    );
 
-      // encrypt data
-      const form = e.currentTarget;
-      const data = new FormData(form);
-
-      data.set(
-        "input",
-        await encrypt(inputRef.current.value, passwordRef.current)
-      );
-
-      // submit form
-      submit(data, { method: "post", action: Routes.PRIVATE_NOTES });
-    },
-    [submit]
-  );
-
-  // we are intentionally not adding a <button type="submit" /> because we never want the plaintext
-  // to ever be submitted (in case javascript is disabled). still using form so that we get all the remix goodies
-  const onClickSubmit = useCallback(() => {
-    formRef.current?.submit();
-  }, []);
+    // submit form
+    fetcher.submit(
+      {
+        input: ciphertext,
+        expiry,
+      },
+      { method: "post", action: Routes.PRIVATE_NOTE_CREATE }
+    );
+  }, [expiry, fetcher]);
 
   // if the form was submitted, and we have action data, a note was created
-  if (actionData) {
+  if (fetcher.type === "done" && passwordRef.current) {
     return (
       <CreatedNote
-        id={actionData.id}
-        key={passwordRef.current || ""}
+        id={fetcher.data.id}
+        secret={passwordRef.current}
         expiry={expiry}
       />
     );
@@ -139,72 +86,63 @@ export default function Index() {
 
   // render form to create note
   return (
-    <>
-      <Title />
+    <div className="w-full mb-4 border rounded-lg bg-zinc-700 border-zinc-600">
+      <div className="px-4 py-2 bg-zinc-800 rounded-t-lg">
+        <textarea
+          id="input"
+          name="input"
+          ref={inputRef}
+          rows={10}
+          className="font-mono w-full px-0 text-sm border-0 bg-zinc-800 focus:ring-0 text-white placeholder-zinc-400"
+          placeholder="Write your note here..."
+          required={true}
+        ></textarea>
+      </div>
 
-      <Form ref={formRef} method="post" onSubmit={onSubmit} replace={true}>
-        <div className="w-full mb-4 border rounded-lg bg-zinc-700 border-zinc-600">
-          <div className="px-4 py-2 bg-zinc-800 rounded-t-lg">
-            <textarea
-              id="input"
-              name="input"
-              ref={inputRef}
-              rows={10}
-              className="font-mono w-full px-0 text-sm border-0 bg-zinc-800 focus:ring-0 text-white placeholder-zinc-400"
-              placeholder="Write your note here..."
-              required={true}
-            ></textarea>
-          </div>
+      <div className="flex px-5 py-2 items-center border-t border-gray-600 bg-zinc-800/50">
+        <label
+          htmlFor="small"
+          className="block text-sm font-medium text-gray-900 dark:text-white"
+        >
+          Note self-destructs
+        </label>
+        <select
+          id="expiry"
+          name="expiry"
+          className="block text-sm ml-2 border rounded-lg bg-zinc-700 border-zinc-600 placeholder-zinc-400 text-white focus:ring-orange-500 focus:border-orange-500"
+          defaultValue={expiry}
+          onChange={(e) => setExpiry(e.target.value)}
+        >
+          {noteExpiries.map((it) => (
+            <option key={it.id} value={it.id}>
+              {it.label}
+            </option>
+          ))}
+        </select>
+      </div>
 
-          <div className="flex px-5 py-2 items-center border-t border-gray-600 bg-zinc-800/50">
-            <label
-              htmlFor="small"
-              className="block text-sm font-medium text-gray-900 dark:text-white"
-            >
-              Note self-destructs
-            </label>
-            <select
-              id="expiry"
-              name="expiry"
-              className="block text-sm ml-2 border rounded-lg bg-zinc-700 border-zinc-600 placeholder-zinc-400 text-white focus:ring-orange-500 focus:border-orange-500"
-              defaultValue={expiry}
-              onChange={(e) => setExpiry(e.target.value)}
-            >
-              {noteExpiries.map((it) => (
-                <option key={it.id} value={it.id}>
-                  {it.label}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="flex items-center justify-end px-3 py-2 border-t border-gray-600">
-            <div className="flex gap-x-2">
-              <Button type="button" label="Create" onClick={onClickSubmit} />
-            </div>
-          </div>
+      <div className="flex items-center justify-end px-3 py-2 border-t border-gray-600">
+        <div className="flex gap-x-2">
+          <Button type="button" label="Create" onClick={onSubmit} />
         </div>
-      </Form>
-      <Security />
-    </>
+      </div>
+    </div>
   );
 }
 
 function CreatedNote({
   id,
-  key,
+  secret,
   expiry,
 }: {
   readonly id: string;
-  readonly key: string;
+  readonly secret: string;
   readonly expiry: string;
 }) {
-  const output = `${window.location.origin}${Routes.PRIVATE_NOTE(id, key)}`;
+  const output = `${window.location.origin}${Routes.PRIVATE_NOTE(id, secret)}`;
 
   return (
     <>
-      <Title />
-
       <div className="w-full mb-4 border rounded-lg bg-zinc-700 border-zinc-600">
         <div className="flex items-center justify-between px-3 py-2 border-b border-gray-600 font-bold">
           <div>Success</div>
@@ -232,8 +170,6 @@ function CreatedNote({
         You have created a private note that you can easily share with anyone
         you want with the link above.
       </p>
-
-      <Security />
     </>
   );
 }

--- a/app/routes/private-note/index.tsx
+++ b/app/routes/private-note/index.tsx
@@ -123,7 +123,12 @@ export default function Index() {
 
       <div className="flex items-center justify-end px-3 py-2 border-t border-gray-600">
         <div className="flex gap-x-2">
-          <Button type="button" label="Create" onClick={onSubmit} />
+          <Button
+            type="button"
+            label="Create"
+            onClick={onSubmit}
+            disabled={fetcher.state === "submitting"}
+          />
         </div>
       </div>
     </div>

--- a/app/utils/aes.ts
+++ b/app/utils/aes.ts
@@ -49,6 +49,11 @@ function base64ToArray(data: string) {
   return Uint8Array.from(atob(data), (c) => c.charCodeAt(0));
 }
 
+/**
+ * Previously this function performed `String.fromCharCode(...data)` which blew through the maximum call stack size,
+ * as the spread operator was building up a stack. Let's make sure we don't do that again.
+ * @param data
+ */
 function arrayToBase64(data: number[]) {
-  return btoa(String.fromCharCode(...data));
+  return btoa(data.reduce((acc, it) => acc + String.fromCharCode(it), ""));
 }


### PR DESCRIPTION
This is going backwards interms of web standards and the conventions remix is trying to push, but since we never want plaintext to be posted to our backend, we need to stop using `<form />`.