### PR TITLE
[Styling] Stop content from shifting when scrollbar appears

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -2,6 +2,10 @@
   color-scheme: dark;
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 @media (min-width: 1024px) {
   .prose :where(.prose > *):not(:where([class~="not-prose"] *)) {
     max-width: 40rem;


### PR DESCRIPTION
This issue is most noticeable in the Word Counter utility.

This is not working in Safari yet.